### PR TITLE
Feature/ath 241

### DIFF
--- a/src/main/scala/com/thirdship/libunit/utils/FuzzyString.scala
+++ b/src/main/scala/com/thirdship/libunit/utils/FuzzyString.scala
@@ -82,6 +82,7 @@ class MixedString(val strings: List[FuzzyString], val separator:String) extends 
 
 }
 
+
 class ExactString(val str: String, val ignoreCase: Boolean = true) extends FuzzyString(str) {
 	override def checkEquality(str: String): Boolean = if(ignoreCase)
 		str.equalsIgnoreCase(baseString)
@@ -114,7 +115,7 @@ abstract class FuzzyString(val baseString: String) extends Comparable[FuzzyStrin
 		baseString.length()
 	}
 
-	override def compareTo(o: FuzzyString): Int = {baseString.compareTo(o.baseString)
+	override def compareTo(o: FuzzyString): Int = {baseString.compareTo(o.baseString)}
 
 	override def equals(obj: Any): Boolean = {
 		obj match {

--- a/src/main/scala/com/thirdship/libunit/utils/FuzzyString.scala
+++ b/src/main/scala/com/thirdship/libunit/utils/FuzzyString.scala
@@ -1,5 +1,6 @@
 package com.thirdship.libunit.utils
 
+import com.google.common.primitives.UnsignedInteger
 import com.thirdship.libunit.ScalarConversion
 import org.atteo.evo.inflector.English
 
@@ -34,6 +35,53 @@ object Helpers {
 	}
 }
 
+class MixedString(val strings: List[FuzzyString], val separator:String) extends FuzzyString({
+	strings.foldLeft(new StringBuilder){ (builder, fuzzy) =>
+		builder.append(fuzzy.toString).append(separator)
+	}.toString()
+
+})
+
+{
+
+	//The length of the component fuzzy strings summed together (no separators)
+	lazy val componentStringLengths = strings.map(_.length).sum
+	//strings.foldLeft(0){(sum, fuzzy) => sum + fuzzy.length}
+
+
+	def this(strings: List[FuzzyString]) {
+		this(strings, "")
+	}
+
+	override def length: Integer = {
+		componentStringLengths
+	}
+
+	override def checkEquality(str: String): Boolean = {
+		//Note: doesn't take separator characters into account in the MixedString or the string to compare it to.
+		var strIndex: Integer = 0
+		for(componentStr:FuzzyString <- strings) {
+			val endIndex = strIndex + componentStr.length
+			if (endIndex >= str.length || !componentStr.checkEquality(str.substring(strIndex, endIndex))) {
+				return false
+			}
+			strIndex = endIndex
+		}
+		strIndex == str.length
+	}
+
+	// should compareTo check case? it doesn't in ExactString
+//	override def compareTo(o:FuzzyString): Integer = {
+//		throw new NotImplementedError("Implement me!")
+//	}
+
+	//This can be implemented if needed, but I'm not sure if it needs to be overridden
+//	override def checkEquality(str:FuzzyString): Boolean = {
+//		throw new NotImplementedError("Implement me!")
+//	}
+
+}
+
 class ExactString(val str: String, val ignoreCase: Boolean = true) extends FuzzyString(str) {
 	override def checkEquality(str: String): Boolean = if(ignoreCase)
 		str.equalsIgnoreCase(baseString)
@@ -62,7 +110,11 @@ abstract class FuzzyString(val baseString: String) extends Comparable[FuzzyStrin
 	def checkEquality(str: String): Boolean
 	def checkEquality(str: FuzzyString): Boolean = checkEquality(str.baseString)
 
-	override def compareTo(o: FuzzyString): Int = baseString.compareTo(o.baseString)
+	def length: Integer = {
+		baseString.length()
+	}
+
+	override def compareTo(o: FuzzyString): Int = {baseString.compareTo(o.baseString)
 
 	override def equals(obj: Any): Boolean = {
 		obj match {

--- a/src/main/scala/com/thirdship/libunit/utils/FuzzyString.scala
+++ b/src/main/scala/com/thirdship/libunit/utils/FuzzyString.scala
@@ -1,6 +1,5 @@
 package com.thirdship.libunit.utils
 
-import com.google.common.primitives.UnsignedInteger
 import com.thirdship.libunit.ScalarConversion
 import org.atteo.evo.inflector.English
 
@@ -40,9 +39,7 @@ class MixedString(val strings: List[FuzzyString], val separator:String) extends 
 		builder.append(fuzzy.toString).append(separator)
 	}.toString()
 
-})
-
-{
+}) {
 
 	//The length of the component fuzzy strings summed together (no separators)
 	lazy val componentStringLengths = strings.map(_.length).sum
@@ -53,13 +50,13 @@ class MixedString(val strings: List[FuzzyString], val separator:String) extends 
 		this(strings, "")
 	}
 
-	override def length: Integer = {
+	override def length: Int = {
 		componentStringLengths
 	}
 
 	override def checkEquality(str: String): Boolean = {
 		//Note: doesn't take separator characters into account in the MixedString or the string to compare it to.
-		var strIndex: Integer = 0
+		var strIndex: Int = 0
 		for(componentStr:FuzzyString <- strings) {
 			val endIndex = strIndex + componentStr.length
 			if (endIndex >= str.length || !componentStr.checkEquality(str.substring(strIndex, endIndex))) {
@@ -71,7 +68,7 @@ class MixedString(val strings: List[FuzzyString], val separator:String) extends 
 	}
 
 	// should compareTo check case? it doesn't in ExactString
-//	override def compareTo(o:FuzzyString): Integer = {
+//	override def compareTo(o:FuzzyString): Int = {
 //		throw new NotImplementedError("Implement me!")
 //	}
 
@@ -111,7 +108,7 @@ abstract class FuzzyString(val baseString: String) extends Comparable[FuzzyStrin
 	def checkEquality(str: String): Boolean
 	def checkEquality(str: FuzzyString): Boolean = checkEquality(str.baseString)
 
-	def length: Integer = {
+	def length: Int = {
 		baseString.length()
 	}
 

--- a/src/test/scala/com/thirdship/libunit/utils/FuzzyStringTest.scala
+++ b/src/test/scala/com/thirdship/libunit/utils/FuzzyStringTest.scala
@@ -230,4 +230,5 @@ class FuzzyStringTest extends FlatSpec with Matchers {
 		).foreach(o => "hello".i.equals(o._1) should be(o._2))
 	}
 
+
 }


### PR DESCRIPTION
Added the MixedString class to the FuzzyString file, along with the override methods. Has a list of FuzzyString objects so that strings can be compared with a mixture of case sensitive and case insensitive comparisons, or whatever the component FuzzyString instances define. Also allows the addition of separator characters to the baseString member between each component FuzzyString, but these separators are ignored in the comparison method.
